### PR TITLE
find-arrow-positions bug

### DIFF
--- a/src/purnam/test/midje.clj
+++ b/src/purnam/test/midje.clj
@@ -4,10 +4,10 @@
 
 (defn find-arrow-positions
   ([forms] (find-arrow-positions forms [] 0))
-  ([[f & more] idxs count]
-     (if f
-       (recur more (if (= f '=>) (conj idxs count) idxs) (inc count))
-       idxs)))
+  ([forms idxs count]
+   (if (empty? forms)
+     idxs
+     (recur (rest forms) (if (= (first forms) '=>) (conj idxs count) idxs) (inc count)))))
 
 (defn fact-groups [forms]
   (let [forms (vec forms)

--- a/test/clj/purnam/test/midje_test.clj
+++ b/test/clj/purnam/test/midje_test.clj
@@ -8,7 +8,11 @@
   => [1]
 
   (find-arrow-positions '(=> 1))
-  => [0])
+  => [0]
+
+  (find-arrow-positions '((= 1 0) => false nil => nil?))
+  => [1 4]
+  )
 
 
 (fact "fact-groups"


### PR DESCRIPTION
There is a bug in find-arrow-positions that occurs if there are multiple test statements in a fact/facts form and any side of the test is a symbol that would evaluate as being falsey (ex. false or nil).  find-arrow-positions uses an if statement to evaluate each symbol when parsing and so any falsey value will terminate the recur and thus return an invalid result for what positions all of the =>'s are in.

I added a fix to recur on non-empty seq's to fix the issue as well as a test that should fail if this bug were to be reintroduced.